### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         python-version: '3.11'
     
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -72,7 +72,7 @@ jobs:
         name: codecov-umbrella
     
     - name: Archive test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-results
@@ -87,7 +87,7 @@ jobs:
         safety check --json --output safety-report.json || true
     
     - name: Upload security reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: security-reports
@@ -152,7 +152,7 @@ jobs:
           .
     
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: comedy-open-mic-build
         path: comedy-open-mic-${{ github.sha }}.tar.gz


### PR DESCRIPTION
Potential fix for [https://github.com/mikebgio/comedy_open_mics/security/code-scanning/3](https://github.com/mikebgio/comedy_open_mics/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required for all jobs. Since the workflow involves actions like checking out the repository, caching dependencies, uploading artifacts, and running security scans, we will set `contents: read` as the default permission. For specific jobs or steps that require additional permissions, we will define job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
